### PR TITLE
Fix data generation script path

### DIFF
--- a/scripts/generate_all_data.py
+++ b/scripts/generate_all_data.py
@@ -1,5 +1,12 @@
 """Generate sample data for all E-group data generators."""
 
+from pathlib import Path
+import sys
+
+# Ensure the repository root is on the Python path so the ``projects`` package
+# imports correctly when this script is executed directly.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from projects.E8_Model.E1.e1_data_generator import E1DataGenerator
 from projects.E8_Model.E2.e2_data_generator import E2DataGenerator
 from projects.E8_Model.E3.e3_data_generator import E3DataGenerator


### PR DESCRIPTION
## Summary
- ensure root path is added to Python path when running `generate_all_data.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: E501, F401, etc.)*
- `pytest -q`
- `python scripts/generate_all_data.py`

------
https://chatgpt.com/codex/tasks/task_e_685ae75ac5b88324a4786b8074dde909