### PR TITLE
Add higher E-group resources

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,11 @@
 # Documentation
 
-This directory contains documentation related to the projects and tasks in this repository. It includes guides, notes, and other relevant information.
+This directory collects references and notes for the E-series projects.
+Below is a list of key documents:
+
+- `e_group_overview.md` -- summary of the E1--E8 generators and their purposes.
+- `matrix_theory_overview.md` -- short introduction to matrix theory and its
+  relation to the project.
+- `higher_e_groups.md` -- conceptual background for the infinite E9--E11 groups.
+
+Use these files as starting points for deeper research and implementation.

--- a/docs/e_group_overview.md
+++ b/docs/e_group_overview.md
@@ -1,0 +1,19 @@
+# E-Groups Overview
+
+This document summarizes the eight finite E-groups used throughout the project.
+Each group corresponds to a specific data generator and embedding dimension.
+
+| Group | Description | Dimensionality |
+|-------|-------------|----------------|
+| **E1** | Time-based embeddings | 1 |
+| **E2** | Spatial embeddings | 2 |
+| **E3** | Momentum embeddings | 3 |
+| **E4** | Energy embeddings | 4 |
+| **E5** | Charge embeddings | 5 |
+| **E6** | Quantum interference embeddings | 6 |
+| **E7** | Emergence embeddings | 7 |
+| **E8** | Closed system embeddings | 8 |
+
+The data generators for each group create random datasets with the specified
+number of features. These datasets are used in simulations to verify that
+transformations across the E-series preserve the expected dimensional structure.

--- a/docs/higher_e_groups.md
+++ b/docs/higher_e_groups.md
@@ -1,0 +1,17 @@
+# Higher E-Groups in M-Theory
+
+Beyond the finite exceptional groups, theorists often discuss
+E9, E10 and E11. These are infinite-dimensional Kac--Moody extensions
+that arise when exploring symmetries of supergravity and string theory.
+
+- **E9** (affine extension) appears in two-dimensional reductions of
+  supergravity. It extends E8 by adding a loop algebra direction.
+- **E10** is a hyperbolic Kac--Moody algebra conjectured to control the
+  chaotic mixmaster dynamics near cosmological singularities.
+- **E11** has been proposed as a unifying symmetry of M-theory,
+  although its physical realization remains speculative.
+
+These higher groups have no finite matrix representations but inspire
+hierarchical structures used in the project. The placeholder data
+generators for E9--E11 provide simple numerical experiments for
+future exploration.

--- a/docs/matrix_theory_overview.md
+++ b/docs/matrix_theory_overview.md
@@ -1,0 +1,13 @@
+# Matrix Theory Primer
+
+Matrix theory (often called the BFSS matrix model) provides a non-perturbative
+formulation of M-theory. In this framework, D0-branes are described by matrices
+whose dynamics capture eleven-dimensional supergravity at low energies.
+
+Key ideas:
+
+- **Supersymmetry** is preserved by representing branes through supermatrices.
+- The large-$N$ limit of these matrices is conjectured to reproduce the full
+  M-theory in a light-cone frame.
+- In the context of the E-series, matrix theory motivates representing each
+  group with fixed-dimensional matrices that evolve through "m-brain" modules.

--- a/projects/E8_Model/E10/README.md
+++ b/projects/E8_Model/E10/README.md
@@ -1,0 +1,3 @@
+# E10 Group
+
+Placeholder for E10-related resources.

--- a/projects/E8_Model/E10/__init__.py
+++ b/projects/E8_Model/E10/__init__.py
@@ -1,0 +1,1 @@
+"""E10 data generator package."""

--- a/projects/E8_Model/E10/e10_data_generator.py
+++ b/projects/E8_Model/E10/e10_data_generator.py
@@ -1,0 +1,31 @@
+"""
+E10 Data Generator
+
+This module contains the data generator for the E10 group. It is part of the
+E series data generators.
+"""
+
+import numpy as np
+
+
+class E10DataGenerator:
+    """A data generator for the E10 group."""
+
+    def __init__(self, data_size=100):
+        """Initialize the data generator with a specified data size."""
+        # Store the desired size of the generated dataset
+        self.data_size = data_size
+        self.data = None
+
+    def generate_data(self):
+        """Generate data for the E10 group."""
+        # Create a random dataset with ten features
+        self.data = np.random.rand(self.data_size, 10)
+        return self.data
+
+    def get_data(self):
+        """Retrieve the generated data."""
+        # Generate data on demand if it does not already exist
+        if self.data is None:
+            self.generate_data()
+        return self.data

--- a/projects/E8_Model/E11/README.md
+++ b/projects/E8_Model/E11/README.md
@@ -1,0 +1,3 @@
+# E11 Group
+
+Placeholder for E11-related resources.

--- a/projects/E8_Model/E11/__init__.py
+++ b/projects/E8_Model/E11/__init__.py
@@ -1,0 +1,1 @@
+"""E11 data generator package."""

--- a/projects/E8_Model/E11/e11_data_generator.py
+++ b/projects/E8_Model/E11/e11_data_generator.py
@@ -1,0 +1,31 @@
+"""
+E11 Data Generator
+
+This module contains the data generator for the E11 group. It is part of the
+E series data generators.
+"""
+
+import numpy as np
+
+
+class E11DataGenerator:
+    """A data generator for the E11 group."""
+
+    def __init__(self, data_size=100):
+        """Initialize the data generator with a specified data size."""
+        # Store the desired size of the generated dataset
+        self.data_size = data_size
+        self.data = None
+
+    def generate_data(self):
+        """Generate data for the E11 group."""
+        # Create a random dataset with eleven features
+        self.data = np.random.rand(self.data_size, 11)
+        return self.data
+
+    def get_data(self):
+        """Retrieve the generated data."""
+        # Generate data on demand if it does not already exist
+        if self.data is None:
+            self.generate_data()
+        return self.data

--- a/projects/E8_Model/E9/README.md
+++ b/projects/E8_Model/E9/README.md
@@ -1,0 +1,3 @@
+# E9 Group
+
+Placeholder for E9-related resources.

--- a/projects/E8_Model/E9/__init__.py
+++ b/projects/E8_Model/E9/__init__.py
@@ -1,0 +1,1 @@
+"""E9 data generator package."""

--- a/projects/E8_Model/E9/e9_data_generator.py
+++ b/projects/E8_Model/E9/e9_data_generator.py
@@ -1,0 +1,31 @@
+"""
+E9 Data Generator
+
+This module contains the data generator for the E9 group. It is part of the
+E series data generators.
+"""
+
+import numpy as np
+
+
+class E9DataGenerator:
+    """A data generator for the E9 group."""
+
+    def __init__(self, data_size=100):
+        """Initialize the data generator with a specified data size."""
+        # Store the desired size of the generated dataset
+        self.data_size = data_size
+        self.data = None
+
+    def generate_data(self):
+        """Generate data for the E9 group."""
+        # Create a random dataset with nine features
+        self.data = np.random.rand(self.data_size, 9)
+        return self.data
+
+    def get_data(self):
+        """Retrieve the generated data."""
+        # Generate data on demand if it does not already exist
+        if self.data is None:
+            self.generate_data()
+        return self.data

--- a/projects/E8_Model/README.md
+++ b/projects/E8_Model/README.md
@@ -8,7 +8,7 @@ The E8 Model project is an exploration of neural network architectures based on 
 
 ## Structure
 
-The project is organized into several directories, each representing a different E group (E1-E8). These directories contain resources and code related to data generators, neural network implementations, and other relevant components.
+The project is organized into several directories, each representing a different E group (E1-E11). These directories contain resources and code related to data generators, neural network implementations, and other relevant components.
 
 - **E1**: Time-based embeddings
 - **E2**: Spatial embeddings
@@ -18,6 +18,9 @@ The project is organized into several directories, each representing a different
 - **E6**: Quantum interference embeddings
 - **E7**: Emergence embeddings
 - **E8**: Closed system embeddings
+- **E9**: Placeholder affine extension
+- **E10**: Placeholder hyperbolic extension
+- **E11**: Placeholder M-theory symmetry
 
 ## Usage
 

--- a/scripts/generate_all_data.py
+++ b/scripts/generate_all_data.py
@@ -15,6 +15,9 @@ from projects.E8_Model.E5.e5_data_generator import E5DataGenerator
 from projects.E8_Model.E6.e6_data_generator import E6DataGenerator
 from projects.E8_Model.E7.e7_data_generator import E7DataGenerator
 from projects.E8_Model.E8.e8_data_generator import E8DataGenerator
+from projects.E8_Model.E9.e9_data_generator import E9DataGenerator
+from projects.E8_Model.E10.e10_data_generator import E10DataGenerator
+from projects.E8_Model.E11.e11_data_generator import E11DataGenerator
 
 
 GENERATORS = [
@@ -26,6 +29,9 @@ GENERATORS = [
     ("E6", E6DataGenerator),
     ("E7", E7DataGenerator),
     ("E8", E8DataGenerator),
+    ("E9", E9DataGenerator),
+    ("E10", E10DataGenerator),
+    ("E11", E11DataGenerator),
 ]
 
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -15,6 +15,9 @@ from projects.E8_Model.E5.e5_data_generator import E5DataGenerator
 from projects.E8_Model.E6.e6_data_generator import E6DataGenerator
 from projects.E8_Model.E7.e7_data_generator import E7DataGenerator
 from projects.E8_Model.E8.e8_data_generator import E8DataGenerator
+from projects.E8_Model.E9.e9_data_generator import E9DataGenerator
+from projects.E8_Model.E10.e10_data_generator import E10DataGenerator
+from projects.E8_Model.E11.e11_data_generator import E11DataGenerator
 
 
 class TestGenerators(unittest.TestCase):
@@ -46,6 +49,15 @@ class TestGenerators(unittest.TestCase):
 
     def test_e8(self):
         self._check_generator(E8DataGenerator, 8)
+
+    def test_e9(self):
+        self._check_generator(E9DataGenerator, 9)
+
+    def test_e10(self):
+        self._check_generator(E10DataGenerator, 10)
+
+    def test_e11(self):
+        self._check_generator(E11DataGenerator, 11)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend E-series with E9–E11 generators
- update documentation with matrix theory and higher-group references
- include new groups in data generation script and tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd884201c8324adac0ba84df76c86