### PR TITLE
Add E4D micro-kernel

### DIFF
--- a/e4d/__init__.py
+++ b/e4d/__init__.py
@@ -1,0 +1,6 @@
+"""E-Series 4D micro-kernel."""
+
+from . import e1, e2, e3, e4, bundle
+from .base import AbstractBaseKernel
+
+__all__ = ["e1", "e2", "e3", "e4", "bundle", "AbstractBaseKernel"]

--- a/e4d/base.py
+++ b/e4d/base.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Shared base interfaces for the e4d kernels."""
+
+from abc import ABC, abstractmethod
+from typing import Iterable
+
+import numpy as np
+from numpy import ndarray
+from scipy.linalg import expm, logm
+
+
+class AbstractBaseKernel(ABC):
+    """Base interface for all E-series kernels."""
+
+    @abstractmethod
+    def encode(self, q: float | ndarray) -> ndarray:
+        """Map physical quantity to Lie-algebra coordinates."""
+
+    @abstractmethod
+    def decode(self, v: ndarray) -> float | ndarray:
+        """Inverse map from Lie coordinates to physical quantity."""
+
+    @abstractmethod
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        """Flow under the canonical generator for time step ``tau``."""
+
+    @abstractmethod
+    def compose(self, *vs: ndarray) -> ndarray:
+        """Lie-algebra addition with BCH correction when needed."""
+
+
+# Helpers -------------------------------------------------------------------
+
+def _bch(a: ndarray, b: ndarray) -> ndarray:
+    """Compute Baker-Campbell-Hausdorff for matrices using log(exp(a) exp(b))."""
+    return logm(expm(a) @ expm(b)).real
+
+

--- a/e4d/bundle/__init__.py
+++ b/e4d/bundle/__init__.py
@@ -1,0 +1,65 @@
+"""Synthesis layer for handling 4-vectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy import ndarray
+
+from ..e1 import Kernel as TKernel
+from ..e2 import Kernel as XKernel
+from ..e3 import Kernel as YKernel
+from ..e4 import Kernel as ZKernel
+
+
+def _minkowski_norm(t: float, x: float, y: float, z: float) -> float:
+    return t**2 - x**2 - y**2 - z**2
+
+
+@dataclass
+class FourVector:
+    """Four-vector encoded via E-series kernels."""
+
+    t: ndarray
+    x: ndarray
+    y: ndarray
+    z: ndarray
+
+    @classmethod
+    def from_scalars(cls, t: float, x: float, y: float, z: float) -> "FourVector":
+        return cls(TKernel().encode(t), XKernel().encode(x),
+                   YKernel().encode(y), ZKernel().encode(z))
+
+    def lorentz_boost(self, beta: float, axis: str = "x") -> "FourVector":
+        gamma = 1.0 / np.sqrt(1 - beta**2)
+        t_val, x_val, y_val, z_val = self.as_scalars()
+        if axis == "x":
+            t_prime = gamma * (t_val - beta * x_val)
+            x_prime = gamma * (x_val - beta * t_val)
+            y_prime, z_prime = y_val, z_val
+        else:
+            t_prime, x_prime, y_prime, z_prime = t_val, x_val, y_val, z_val
+        return FourVector.from_scalars(t_prime, x_prime, y_prime, z_prime)
+
+    def as_array(self) -> ndarray:
+        return np.hstack([
+            self.t.flatten(),
+            self.x.flatten(),
+            self.y.flatten(),
+            self.z.flatten(),
+        ])
+
+    def as_scalars(self) -> tuple[float, float, float, float]:
+        return (
+            TKernel().decode(self.t),
+            XKernel().decode(self.x),
+            YKernel().decode(self.y),
+            ZKernel().decode(self.z),
+        )
+
+    def minkowski_norm(self) -> float:
+        t, x, y, z = self.as_scalars()
+        return _minkowski_norm(t, x, y, z)
+
+__all__ = ["FourVector"]

--- a/e4d/e1/__init__.py
+++ b/e4d/e1/__init__.py
@@ -1,0 +1,2 @@
+from .kernel import Kernel
+__all__ = ["Kernel"]

--- a/e4d/e1/kernel.py
+++ b/e4d/e1/kernel.py
@@ -1,0 +1,25 @@
+"""Time kernel implementing the E1 algebra."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy import ndarray
+
+from ..base import AbstractBaseKernel
+
+
+class Kernel(AbstractBaseKernel):
+    """E1 time kernel (abelian)."""
+
+    def encode(self, q: float | ndarray) -> ndarray:
+        return np.atleast_1d(q).astype(float)
+
+    def decode(self, v: ndarray) -> float | ndarray:
+        v = np.asarray(v, dtype=float)
+        return v[0] if v.size == 1 else v
+
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        return np.asarray(v, dtype=float) + tau
+
+    def compose(self, *vs: ndarray) -> ndarray:
+        return sum(np.asarray(v, dtype=float) for v in vs)

--- a/e4d/e2/__init__.py
+++ b/e4d/e2/__init__.py
@@ -1,0 +1,2 @@
+from .kernel import Kernel
+__all__ = ["Kernel"]

--- a/e4d/e2/kernel.py
+++ b/e4d/e2/kernel.py
@@ -1,0 +1,34 @@
+"""X-axis kernel implementing sl(2,R)."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy import ndarray
+from scipy.linalg import expm, logm
+
+from ..base import AbstractBaseKernel, _bch
+
+# Cartan element for sl(2)
+_H = np.array([[0.5, 0.0], [0.0, -0.5]], dtype=float)
+
+
+class Kernel(AbstractBaseKernel):
+    """E2 kernel based on sl(2,R)."""
+
+    def encode(self, q: float | ndarray) -> ndarray:
+        q = float(np.squeeze(q))
+        return q * _H
+
+    def decode(self, v: ndarray) -> float:
+        v = np.asarray(v, dtype=float)
+        return float(v[0, 0] - v[1, 1])
+
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        v = np.asarray(v, dtype=float)
+        return expm(tau * v)
+
+    def compose(self, *vs: ndarray) -> ndarray:
+        result = np.asarray(vs[0], dtype=float)
+        for nxt in vs[1:]:
+            result = _bch(result, np.asarray(nxt, dtype=float))
+        return result

--- a/e4d/e3/__init__.py
+++ b/e4d/e3/__init__.py
@@ -1,0 +1,2 @@
+from .kernel import Kernel
+__all__ = ["Kernel"]

--- a/e4d/e3/kernel.py
+++ b/e4d/e3/kernel.py
@@ -1,0 +1,37 @@
+"""Y-axis kernel using sl(3) \oplus sl(2)."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy import ndarray
+from scipy.linalg import expm
+
+from ..base import AbstractBaseKernel, _bch
+
+# Cartan elements
+_H3 = np.diag([2.0 / 3.0, -1.0 / 3.0, -1.0 / 3.0])
+_H2 = np.array([[0.5, 0.0], [0.0, -0.5]], dtype=float)
+
+
+class Kernel(AbstractBaseKernel):
+    """E3 kernel based on sl(3) ⊕ sl(2)."""
+
+    def encode(self, q: float | ndarray) -> ndarray:
+        q = float(np.squeeze(q))
+        top = q * _H3
+        bottom = np.zeros_like(_H2)
+        return np.block([[top, np.zeros((3, 2))], [np.zeros((2, 3)), bottom]])
+
+    def decode(self, v: ndarray) -> float:
+        v = np.asarray(v, dtype=float)
+        return float(v[0, 0] - v[1, 1])
+
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        v = np.asarray(v, dtype=float)
+        return expm(tau * v)
+
+    def compose(self, *vs: ndarray) -> ndarray:
+        result = np.asarray(vs[0], dtype=float)
+        for nxt in vs[1:]:
+            result = _bch(result, np.asarray(nxt, dtype=float))
+        return result

--- a/e4d/e4/__init__.py
+++ b/e4d/e4/__init__.py
@@ -1,0 +1,2 @@
+from .kernel import Kernel
+__all__ = ["Kernel"]

--- a/e4d/e4/kernel.py
+++ b/e4d/e4/kernel.py
@@ -1,0 +1,33 @@
+"""Z-axis kernel using sl(5)."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy import ndarray
+from scipy.linalg import expm
+
+from ..base import AbstractBaseKernel, _bch
+
+_H5 = np.diag([0.4, 0.2, 0.0, -0.2, -0.4])
+
+
+class Kernel(AbstractBaseKernel):
+    """E4 kernel based on sl(5)."""
+
+    def encode(self, q: float | ndarray) -> ndarray:
+        q = float(np.squeeze(q))
+        return q * _H5
+
+    def decode(self, v: ndarray) -> float:
+        v = np.asarray(v, dtype=float)
+        return float((v[0, 0] - v[-1, -1]) / 0.8)
+
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        v = np.asarray(v, dtype=float)
+        return expm(tau * v)
+
+    def compose(self, *vs: ndarray) -> ndarray:
+        result = np.asarray(vs[0], dtype=float)
+        for nxt in vs[1:]:
+            result = _bch(result, np.asarray(nxt, dtype=float))
+        return result

--- a/tests/test_bch.py
+++ b/tests/test_bch.py
@@ -1,0 +1,20 @@
+"""Validate BCH composition for sl(2,R)."""
+
+import sys
+from pathlib import Path
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy.linalg import expm, logm
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from e4d.e2 import Kernel
+
+
+def test_bch_compose():
+    k = Kernel()
+    a = k.encode(0.2)
+    b = k.encode(-0.3)
+    composed = k.compose(a, b)
+    reference = logm(expm(a) @ expm(b)).real
+    assert_allclose(composed, reference, rtol=1e-12, atol=1e-12)

--- a/tests/test_fourvector.py
+++ b/tests/test_fourvector.py
@@ -1,0 +1,18 @@
+"""Minkowski norm invariance under Lorentz boosts."""
+
+import sys
+from pathlib import Path
+import numpy as np
+from numpy.testing import assert_allclose
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from e4d.bundle import FourVector
+
+
+def test_minkowski_invariance():
+    fv = FourVector.from_scalars(2.0, 0.5, -0.1, 0.0)
+    norm_before = fv.minkowski_norm()
+    boosted = fv.lorentz_boost(0.3, axis="x")
+    norm_after = boosted.minkowski_norm()
+    assert_allclose(norm_after, norm_before, rtol=1e-12, atol=1e-12)

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -1,0 +1,35 @@
+"""Encode-decode round-trip accuracy tests."""
+
+import sys
+from pathlib import Path
+import numpy as np
+from numpy.testing import assert_allclose
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from e4d.e1 import Kernel as E1
+from e4d.e2 import Kernel as E2
+from e4d.e3 import Kernel as E3
+from e4d.e4 import Kernel as E4
+
+
+def _roundtrip(kernel, value):
+    encoded = kernel.encode(value)
+    decoded = kernel.decode(encoded)
+    assert_allclose(decoded, value, rtol=1e-12, atol=1e-12)
+
+
+def test_e1_roundtrip():
+    _roundtrip(E1(), 3.14)
+
+
+def test_e2_roundtrip():
+    _roundtrip(E2(), 1.23)
+
+
+def test_e3_roundtrip():
+    _roundtrip(E3(), -0.5)
+
+
+def test_e4_roundtrip():
+    _roundtrip(E4(), 2.0)


### PR DESCRIPTION
## Summary
- implement `e4d` micro-kernel with E1–E4 kernels
- add synthesis layer for 4-vectors
- provide unit tests for encode/decode, BCH composition and Lorentz boosts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb037f4c883248bfb98fa2177dd7f