### PR TITLE
Implement E4D micro-kernel

### DIFF
--- a/e4d/__init__.py
+++ b/e4d/__init__.py
@@ -1,0 +1,5 @@
+"""E-series 4D micro-kernel package."""
+
+from . import e1, e2, e3, e4, bundle
+
+__all__ = ["e1", "e2", "e3", "e4", "bundle"]

--- a/e4d/base.py
+++ b/e4d/base.py
@@ -1,0 +1,29 @@
+import abc
+import numpy as np
+from numpy import ndarray
+from scipy.linalg import expm, logm
+
+
+class AbstractBaseKernel(abc.ABC):
+    """Base interface for all kernels."""
+
+    @abc.abstractmethod
+    def encode(self, q: float | ndarray) -> ndarray:
+        """Map physical quantity to Lie-algebra coordinates."""
+
+    @abc.abstractmethod
+    def decode(self, v: ndarray) -> float | ndarray:
+        """Map Lie-algebra coordinates back to physical quantity."""
+
+    @abc.abstractmethod
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        """Flow under canonical generator by time step ``tau``."""
+
+    @abc.abstractmethod
+    def compose(self, *vs: ndarray) -> ndarray:
+        """Compose algebra elements with BCH if necessary."""
+
+
+def bch(a: ndarray, b: ndarray) -> ndarray:
+    """Baker-Campbell-Hausdorff using matrix logarithms."""
+    return logm(expm(a) @ expm(b)).real

--- a/e4d/bundle/__init__.py
+++ b/e4d/bundle/__init__.py
@@ -1,0 +1,1 @@
+from .fourvector import FourVector

--- a/e4d/bundle/fourvector.py
+++ b/e4d/bundle/fourvector.py
@@ -1,0 +1,50 @@
+import numpy as np
+from numpy import ndarray
+
+from ..e1 import Kernel as TKernel
+from ..e2 import Kernel as XKernel
+from ..e3 import Kernel as YKernel
+from ..e4 import Kernel as ZKernel
+
+
+class FourVector:
+    """Simple four-vector built from E-series kernels."""
+
+    def __init__(self, t: float, x: float, y: float, z: float):
+        self.t_kernel = TKernel()
+        self.x_kernel = XKernel()
+        self.y_kernel = YKernel()
+        self.z_kernel = ZKernel()
+        self.t = self.t_kernel.encode(t)
+        self.x = self.x_kernel.encode(x)
+        self.y = self.y_kernel.encode(y)
+        self.z = self.z_kernel.encode(z)
+
+    def _decode_components(self) -> tuple[float, float, float, float]:
+        return (
+            self.t_kernel.decode(self.t),
+            self.x_kernel.decode(self.x),
+            self.y_kernel.decode(self.y),
+            self.z_kernel.decode(self.z),
+        )
+
+    def lorentz_boost(self, beta: float, axis: str = "x") -> "FourVector":
+        gamma = 1.0 / np.sqrt(1 - beta ** 2)
+        t, x, y, z = self._decode_components()
+        if axis == "x":
+            t_new = gamma * (t - beta * x)
+            x_new = gamma * (x - beta * t)
+            y_new, z_new = y, z
+        elif axis == "y":
+            t_new = gamma * (t - beta * y)
+            y_new = gamma * (y - beta * t)
+            x_new, z_new = x, z
+        else:
+            t_new = gamma * (t - beta * z)
+            z_new = gamma * (z - beta * t)
+            x_new, y_new = x, y
+        return FourVector(t_new, x_new, y_new, z_new)
+
+    def as_array(self) -> ndarray:
+        flat = [self.t, self.x.flatten(), self.y.flatten(), self.z.flatten()]
+        return np.hstack(flat)

--- a/e4d/e1/__init__.py
+++ b/e4d/e1/__init__.py
@@ -1,0 +1,1 @@
+from .kernel import Kernel

--- a/e4d/e1/kernel.py
+++ b/e4d/e1/kernel.py
@@ -1,0 +1,20 @@
+import numpy as np
+from numpy import ndarray
+
+from ..base import AbstractBaseKernel
+
+
+class Kernel(AbstractBaseKernel):
+    """Time kernel for the E1 algebra."""
+
+    def encode(self, q: float | ndarray) -> ndarray:
+        return np.array([q], dtype=float)
+
+    def decode(self, v: ndarray) -> float | ndarray:
+        return float(v[0])
+
+    def compose(self, *vs: ndarray) -> ndarray:
+        return np.array([sum(v[0] for v in vs)], dtype=float)
+
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        return self.compose(v, np.array([tau]))

--- a/e4d/e2/__init__.py
+++ b/e4d/e2/__init__.py
@@ -1,0 +1,1 @@
+from .kernel import Kernel

--- a/e4d/e2/kernel.py
+++ b/e4d/e2/kernel.py
@@ -1,0 +1,27 @@
+import numpy as np
+from numpy import ndarray
+from scipy.linalg import expm
+
+from ..base import AbstractBaseKernel, bch
+
+
+H = np.array([[1.0, 0.0], [0.0, -1.0]])
+
+
+class Kernel(AbstractBaseKernel):
+    """X-axis kernel based on sl(2)."""
+
+    def encode(self, q: float | ndarray) -> ndarray:
+        return q * H
+
+    def decode(self, v: ndarray) -> float | ndarray:
+        return float(v[0, 0])
+
+    def compose(self, *vs: ndarray) -> ndarray:
+        result = vs[0]
+        for v in vs[1:]:
+            result = bch(result, v)
+        return result
+
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        return self.compose(v, tau * H)

--- a/e4d/e3/__init__.py
+++ b/e4d/e3/__init__.py
@@ -1,0 +1,1 @@
+from .kernel import Kernel

--- a/e4d/e3/kernel.py
+++ b/e4d/e3/kernel.py
@@ -1,0 +1,29 @@
+import numpy as np
+from numpy import ndarray
+
+from ..base import AbstractBaseKernel, bch
+from ..e2.kernel import H as H2
+
+H3 = np.diag([1.0, -1.0, 0.0])
+
+
+class Kernel(AbstractBaseKernel):
+    """Y-axis kernel using sl(3) ⊕ sl(2)."""
+
+    def encode(self, q: float | ndarray) -> ndarray:
+        top = q * H3
+        bottom = np.zeros_like(H2)
+        return np.block([[top, np.zeros((3, 2))], [np.zeros((2, 3)), bottom]])
+
+    def decode(self, v: ndarray) -> float | ndarray:
+        return float(v[0, 0])
+
+    def compose(self, *vs: ndarray) -> ndarray:
+        result = vs[0]
+        for v in vs[1:]:
+            result = bch(result, v)
+        return result
+
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        generator = np.block([[tau * H3, np.zeros((3, 2))], [np.zeros((2, 3)), np.zeros_like(H2)]])
+        return self.compose(v, generator)

--- a/e4d/e4/__init__.py
+++ b/e4d/e4/__init__.py
@@ -1,0 +1,1 @@
+from .kernel import Kernel

--- a/e4d/e4/kernel.py
+++ b/e4d/e4/kernel.py
@@ -1,0 +1,25 @@
+import numpy as np
+from numpy import ndarray
+
+from ..base import AbstractBaseKernel, bch
+
+H4 = np.diag([1.0, -1.0, 0.0, 0.0, 0.0])
+
+
+class Kernel(AbstractBaseKernel):
+    """Z-axis kernel using sl(5)."""
+
+    def encode(self, q: float | ndarray) -> ndarray:
+        return q * H4
+
+    def decode(self, v: ndarray) -> float | ndarray:
+        return float(v[0, 0])
+
+    def compose(self, *vs: ndarray) -> ndarray:
+        result = vs[0]
+        for v in vs[1:]:
+            result = bch(result, v)
+        return result
+
+    def evolve(self, v: ndarray, tau: float) -> ndarray:
+        return self.compose(v, tau * H4)

--- a/tests/test_bch.py
+++ b/tests/test_bch.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+from scipy.linalg import logm, expm
+from e4d.e2 import Kernel
+
+
+def test_bch_sl2():
+    k = Kernel()
+    a = k.encode(0.2)
+    b = k.encode(-0.1)
+    comp_kernel = k.compose(a, b)
+    comp_ref = logm(expm(a) @ expm(b)).real
+    assert np.allclose(comp_kernel, comp_ref, atol=1e-10)

--- a/tests/test_fourvector.py
+++ b/tests/test_fourvector.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+from e4d.bundle import FourVector
+
+
+def minkowski_norm(v: FourVector) -> float:
+    t, x, y, z = v._decode_components()
+    return -t ** 2 + x ** 2 + y ** 2 + z ** 2
+
+
+def test_lorentz_invariance():
+    fv = FourVector(1.0, 0.2, -0.1, 0.3)
+    norm_before = minkowski_norm(fv)
+    boosted = fv.lorentz_boost(0.3, axis="x")
+    norm_after = minkowski_norm(boosted)
+    assert np.allclose(norm_before, norm_after, atol=1e-10)

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+from e4d.e1 import Kernel as E1
+from e4d.e2 import Kernel as E2
+from e4d.e3 import Kernel as E3
+from e4d.e4 import Kernel as E4
+
+
+def _roundtrip(kernel):
+    q = np.random.rand()
+    encoded = kernel.encode(q)
+    decoded = kernel.decode(encoded)
+    assert np.allclose(q, decoded, rtol=1e-12)
+
+
+def test_roundtrip_e1():
+    _roundtrip(E1())
+
+
+def test_roundtrip_e2():
+    _roundtrip(E2())
+
+
+def test_roundtrip_e3():
+    _roundtrip(E3())
+
+
+def test_roundtrip_e4():
+    _roundtrip(E4())


### PR DESCRIPTION
## Summary
- add `e4d` micro-kernel packages for E1–E4
- implement basic FourVector with Lorentz boost
- test encode/decode round-trip, BCH compose and Lorentz invariance

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb037f4c883248bfb98fa2177dd7f