### PR TITLE
Add repository manifest generator

### DIFF
--- a/scripts/repo_inventory.py
+++ b/scripts/repo_inventory.py
@@ -1,0 +1,51 @@
+"""Repository inventory utility."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List
+
+EXT_MAP: Dict[str, List[str]] = {
+    "code": [".py", ".ipynb", ".sage", ".m", ".jl"],
+    "data": [".json", ".csv", ".npy", ".pkl"],
+    "docs": [".md", ".pdf", ".tex", ".bib"],
+}
+
+
+def classify_file(path: Path) -> str | None:
+    """Classify file by extension or CI location."""
+    ci_file = path.match(".github/workflows/*.yml")
+    ci_file |= path.name.startswith("Dockerfile")
+    ci_file |= path.name.startswith("requirements")
+    if ci_file:
+        return "ci"
+    for category, exts in EXT_MAP.items():
+        if path.suffix in exts:
+            return category
+    return None
+
+
+def build_manifest(root: Path) -> Dict[str, List[str]]:
+    """Build manifest mapping categories to relative file paths."""
+    manifest: Dict[str, List[str]] = {"code": [], "data": [], "docs": [], "ci": []}
+    for file in root.rglob("*"):
+        if not file.is_file():
+            continue
+        category = classify_file(file)
+        if category:
+            manifest[category].append(str(file.relative_to(root)))
+    return manifest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate repository manifest")
+    parser.add_argument("--output", default="repo_manifest.yaml", help="Output manifest path")
+    args = parser.parse_args()
+
+    manifest = build_manifest(Path.cwd())
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.repo_inventory import build_manifest
+
+
+def test_manifest_contains_inventory_script(tmp_path):
+    manifest = build_manifest(Path.cwd())
+    assert 'scripts/repo_inventory.py' in manifest['code']


### PR DESCRIPTION
## Summary
- add `repo_inventory.py` for generating repo manifests
- test the new inventory tool

## Testing
- `flake8 scripts/repo_inventory.py tests/test_inventory.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d93cfef188324b871816f58cbded7