### PR TITLE
Enhance E6–E8 generators with Lie algebra data

### DIFF
--- a/projects/E8_Model/E6/e6_data_generator.py
+++ b/projects/E8_Model/E6/e6_data_generator.py
@@ -7,6 +7,8 @@ E series data generators.
 
 import numpy as np
 
+from ...lie_algebra import root_system
+
 
 class E6DataGenerator:
     """A data generator for the E6 group."""
@@ -18,9 +20,10 @@ class E6DataGenerator:
         self.data = None
 
     def generate_data(self):
-        """Generate data for the E6 group."""
-        # Create a random dataset with six features
-        self.data = np.random.rand(self.data_size, 6)
+        """Generate data for the E6 group using its root system."""
+        roots = root_system("E6")
+        idx = np.random.choice(len(roots), self.data_size, replace=True)
+        self.data = roots[idx]
         return self.data
 
     def get_data(self):
@@ -29,3 +32,18 @@ class E6DataGenerator:
         if self.data is None:
             self.generate_data()
         return self.data
+
+    def export_data(self, path, fmt="csv"):
+        """Export generated data to ``path`` in the given format."""
+        data = self.get_data()
+        if fmt == "csv":
+            np.savetxt(path, data, delimiter=",")
+        elif fmt == "json":
+            import json
+
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(data.tolist(), fh)
+        elif fmt == "npz":
+            np.savez(path, data=data)
+        else:
+            raise ValueError(f"Unknown format: {fmt}")

--- a/projects/E8_Model/E7/e7_data_generator.py
+++ b/projects/E8_Model/E7/e7_data_generator.py
@@ -7,6 +7,8 @@ E series data generators.
 
 import numpy as np
 
+from ...lie_algebra import root_system
+
 
 class E7DataGenerator:
     """A data generator for the E7 group."""
@@ -18,9 +20,10 @@ class E7DataGenerator:
         self.data = None
 
     def generate_data(self):
-        """Generate data for the E7 group."""
-        # Create a random dataset with seven features
-        self.data = np.random.rand(self.data_size, 7)
+        """Generate data for the E7 group using its root system."""
+        roots = root_system("E7")
+        idx = np.random.choice(len(roots), self.data_size, replace=True)
+        self.data = roots[idx]
         return self.data
 
     def get_data(self):
@@ -29,3 +32,18 @@ class E7DataGenerator:
         if self.data is None:
             self.generate_data()
         return self.data
+
+    def export_data(self, path, fmt="csv"):
+        """Export generated data to ``path`` in the given format."""
+        data = self.get_data()
+        if fmt == "csv":
+            np.savetxt(path, data, delimiter=",")
+        elif fmt == "json":
+            import json
+
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(data.tolist(), fh)
+        elif fmt == "npz":
+            np.savez(path, data=data)
+        else:
+            raise ValueError(f"Unknown format: {fmt}")

--- a/projects/E8_Model/E8/e8_data_generator.py
+++ b/projects/E8_Model/E8/e8_data_generator.py
@@ -7,6 +7,8 @@ E series data generators.
 
 import numpy as np
 
+from ...lie_algebra import root_system
+
 
 class E8DataGenerator:
     """A data generator for the E8 group."""
@@ -18,9 +20,10 @@ class E8DataGenerator:
         self.data = None
 
     def generate_data(self):
-        """Generate data for the E8 group."""
-        # Create a random dataset with eight features
-        self.data = np.random.rand(self.data_size, 8)
+        """Generate data for the E8 group using its root system."""
+        roots = root_system("E8")
+        idx = np.random.choice(len(roots), self.data_size, replace=True)
+        self.data = roots[idx]
         return self.data
 
     def get_data(self):
@@ -29,3 +32,18 @@ class E8DataGenerator:
         if self.data is None:
             self.generate_data()
         return self.data
+
+    def export_data(self, path, fmt="csv"):
+        """Export generated data to ``path`` in the given format."""
+        data = self.get_data()
+        if fmt == "csv":
+            np.savetxt(path, data, delimiter=",")
+        elif fmt == "json":
+            import json
+
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(data.tolist(), fh)
+        elif fmt == "npz":
+            np.savez(path, data=data)
+        else:
+            raise ValueError(f"Unknown format: {fmt}")

--- a/projects/constants.py
+++ b/projects/constants.py
@@ -1,0 +1,10 @@
+"""Constants for exceptional Lie groups.
+
+Values sourced from standard tables in Georgi and Bourbaki [ref].
+"""
+
+WEYL_GROUP_ORDER = {
+    "E6": 51840,
+    "E7": 2903040,
+    "E8": 696729600,
+}

--- a/projects/lie_algebra.py
+++ b/projects/lie_algebra.py
@@ -1,0 +1,33 @@
+"""Utility functions for exceptional Lie algebras."""
+
+from __future__ import annotations
+
+import numpy as np
+from sympy.liealgebras.cartan_matrix import CartanMatrix
+from sympy.liealgebras.root_system import RootSystem
+from sympy.liealgebras.weyl_group import WeylGroup
+
+from .constants import WEYL_GROUP_ORDER
+
+
+def cartan_matrix(group: str) -> np.ndarray:
+    """Return the Cartan matrix for an exceptional group."""
+    return np.array(CartanMatrix(group), dtype=int)
+
+
+def root_system(group: str) -> np.ndarray:
+    """Return the simple root system as an array."""
+    rs = RootSystem(group).all_roots()
+    root_vecs = np.array([rs[i] for i in sorted(rs)], dtype=int)
+    if group.startswith("E"):
+        rank = int(group[1:])
+        if rank < root_vecs.shape[1]:
+            root_vecs = root_vecs[:, :rank]
+    return root_vecs
+
+
+def weyl_group_order(group: str) -> int:
+    """Return the Weyl group order for ``group``."""
+    if group in WEYL_GROUP_ORDER:
+        return WEYL_GROUP_ORDER[group]
+    return WeylGroup(group).group_order()

--- a/scripts/generate_all_data.py
+++ b/scripts/generate_all_data.py
@@ -1,7 +1,8 @@
-"""Generate sample data for all E-group data generators."""
+"""Generate data for E-group generators with export utilities."""
 
 from pathlib import Path
 import sys
+import argparse
 
 # Ensure the repository root is on the Python path so the ``projects`` package
 # imports correctly when this script is executed directly.
@@ -20,26 +21,40 @@ from projects.E8_Model.E10.e10_data_generator import E10DataGenerator
 from projects.E8_Model.E11.e11_data_generator import E11DataGenerator
 
 
-GENERATORS = [
-    ("E1", E1DataGenerator),
-    ("E2", E2DataGenerator),
-    ("E3", E3DataGenerator),
-    ("E4", E4DataGenerator),
-    ("E5", E5DataGenerator),
-    ("E6", E6DataGenerator),
-    ("E7", E7DataGenerator),
-    ("E8", E8DataGenerator),
-    ("E9", E9DataGenerator),
-    ("E10", E10DataGenerator),
-    ("E11", E11DataGenerator),
-]
+GENERATORS = {
+    "E1": E1DataGenerator,
+    "E2": E2DataGenerator,
+    "E3": E3DataGenerator,
+    "E4": E4DataGenerator,
+    "E5": E5DataGenerator,
+    "E6": E6DataGenerator,
+    "E7": E7DataGenerator,
+    "E8": E8DataGenerator,
+    "E9": E9DataGenerator,
+    "E10": E10DataGenerator,
+    "E11": E11DataGenerator,
+}
 
 
-def main():
-    for name, generator_cls in GENERATORS:
-        generator = generator_cls(data_size=5)
-        data = generator.get_data()
-        print(f"{name}: {data.shape}")
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate E-series datasets")
+    parser.add_argument("--group", default="E8", help="Exceptional group label")
+    parser.add_argument("--size", type=int, default=100, help="Dataset size")
+    parser.add_argument(
+        "--format", choices=["csv", "json", "npz"], default="csv", help="Export format"
+    )
+    parser.add_argument("--out", required=True, help="Output file path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.group not in GENERATORS:
+        raise ValueError(f"Unknown group: {args.group}")
+    generator = GENERATORS[args.group](data_size=args.size)
+    generator.generate_data()
+    generator.export_data(args.out, args.format)
+    print(f"Saved {args.group} data -> {args.out}")
 
 
 if __name__ == "__main__":

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,0 +1,18 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from projects.lie_algebra import cartan_matrix, root_system, weyl_group_order
+
+
+class TestInvariants(unittest.TestCase):
+    def test_e8_invariants(self):
+        self.assertEqual(len(root_system("E8")), 240)
+        self.assertEqual(cartan_matrix("E8").shape, (8, 8))
+        self.assertEqual(weyl_group_order("E8"), 696729600)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `projects/constants.py` for tabulated Weyl group orders
- implement `projects/lie_algebra.py` with Cartan matrix, root system and Weyl order helpers
- update E6–E8 data generators to draw samples from their root systems and export in multiple formats
- extend CLI `scripts/generate_all_data.py` with argument parsing and export support
- add invariant unit tests for the E8 algebra

## Testing
- `ruff check .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685deb3246a88324acc45419b7888ec2