### PR TITLE
Implement root system generator

### DIFF
--- a/lie_algebra/__init__.py
+++ b/lie_algebra/__init__.py
@@ -2,10 +2,12 @@
 
 from .lie_algebra import cartan_matrix, root_system, weyl_group_order
 from .invariants import quadratic_invariant
+from .root_system_generator import RootSystemGenerator
 
 __all__ = [
     "cartan_matrix",
     "root_system",
     "weyl_group_order",
     "quadratic_invariant",
+    "RootSystemGenerator",
 ]

--- a/lie_algebra/root_system_generator.py
+++ b/lie_algebra/root_system_generator.py
@@ -1,0 +1,72 @@
+"""Generate root systems for simple Lie algebras with caching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import numpy as np
+
+from .lie_algebra import root_system as _root_system
+
+
+class RootSystemGenerator:
+    """Generate root vectors for A, D and E series Lie algebras.
+
+    Parameters
+    ----------
+    cache_dir:
+        Directory where generated root arrays are stored.
+    """
+
+    def __init__(self, cache_dir: Path | str = Path("data/roots")) -> None:
+        self.cache_dir = Path(cache_dir)
+
+    def roots(self, label: str) -> np.ndarray:
+        """Return the root system for ``label``.
+
+        The result is cached under ``cache_dir`` as ``<label>.npy``.
+        Supported labels include ``An`` (n>=1), ``Dn`` (n>=4), ``E6``, ``E7``,
+        and ``E8``.
+        """
+
+        file_path = self.cache_dir / f"{label}.npy"
+        if file_path.exists():
+            return np.load(file_path)
+
+        if label.startswith("A"):
+            rank = int(label[1:])
+            roots = self._a_roots(rank)
+        elif label.startswith("D"):
+            rank = int(label[1:])
+            roots = self._d_roots(rank)
+        elif label in {"E6", "E7", "E8"}:
+            roots = _root_system(label)
+        else:
+            raise ValueError(f"Unsupported group: {label}")
+
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        np.save(file_path, roots)
+        return roots
+
+    @staticmethod
+    def _a_roots(n: int) -> np.ndarray:
+        m = n + 1
+        basis = np.eye(m)
+        roots = []
+        for i in range(m):
+            for j in range(m):
+                if i != j:
+                    roots.append(basis[i] - basis[j])
+        return np.array(roots)
+
+    @staticmethod
+    def _d_roots(n: int) -> np.ndarray:
+        roots = []
+        for i in range(n):
+            for j in range(i + 1, n):
+                for s1 in (1.0, -1.0):
+                    for s2 in (1.0, -1.0):
+                        vec = np.zeros(n)
+                        vec[i] = s1
+                        vec[j] = s2
+                        roots.append(vec)
+        return np.array(roots)

--- a/tests/test_root_system_generator.py
+++ b/tests/test_root_system_generator.py
@@ -1,0 +1,18 @@
+import numpy as np
+from pathlib import Path
+
+from lie_algebra import RootSystemGenerator
+
+
+def test_a2_generation(tmp_path: Path) -> None:
+    gen = RootSystemGenerator(cache_dir=tmp_path)
+    roots = gen.roots("A2")
+    assert roots.shape == (6, 3)
+    roots2 = gen.roots("A2")
+    assert np.array_equal(roots, roots2)
+
+
+def test_d4_count(tmp_path: Path) -> None:
+    gen = RootSystemGenerator(cache_dir=tmp_path)
+    roots = gen.roots("D4")
+    assert roots.shape == (24, 4)


### PR DESCRIPTION
## Summary
- add `RootSystemGenerator` for caching and generating An, Dn and En roots
- expose `RootSystemGenerator` in `lie_algebra` package
- test A2 and D4 root generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e04c31f3c8324857ef14000418ecc