### PR TITLE
Improve FourVector boost validation

### DIFF
--- a/e4d/bundle/fourvector.py
+++ b/e4d/bundle/fourvector.py
@@ -29,6 +29,16 @@ class FourVector:
         )
 
     def lorentz_boost(self, beta: float, axis: str = "x") -> "FourVector":
+        """Return a new four-vector boosted along ``axis``.
+
+        Parameters
+        ----------
+        beta:
+            Normalised velocity (``v/c``) of the boost.
+        axis:
+            Spatial axis for the boost – ``"x"``, ``"y"`` or ``"z"``.
+        """
+
         gamma = 1.0 / np.sqrt(1 - beta ** 2)
         t, x, y, z = self._decode_components()
         if axis == "x":
@@ -39,10 +49,12 @@ class FourVector:
             t_new = gamma * (t - beta * y)
             y_new = gamma * (y - beta * t)
             x_new, z_new = x, z
-        else:
+        elif axis == "z":
             t_new = gamma * (t - beta * z)
             z_new = gamma * (z - beta * t)
             x_new, y_new = x, y
+        else:
+            raise ValueError("axis must be 'x', 'y' or 'z'")
         return FourVector(t_new, x_new, y_new, z_new)
 
     def as_array(self) -> ndarray:

--- a/tests/test_fourvector.py
+++ b/tests/test_fourvector.py
@@ -3,6 +3,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import numpy as np
+import pytest
 from e4d.bundle import FourVector
 
 
@@ -17,3 +18,16 @@ def test_lorentz_invariance():
     boosted = fv.lorentz_boost(0.3, axis="x")
     norm_after = minkowski_norm(boosted)
     assert np.allclose(norm_before, norm_after, atol=1e-10)
+
+
+def test_boost_axes():
+    fv = FourVector(1.0, 0.2, -0.1, 0.3)
+    for ax in ("x", "y", "z"):
+        boosted = fv.lorentz_boost(0.1, axis=ax)
+        assert np.allclose(minkowski_norm(fv), minkowski_norm(boosted), atol=1e-10)
+
+
+def test_invalid_axis():
+    fv = FourVector(1.0, 0.0, 0.0, 0.0)
+    with pytest.raises(ValueError):
+        fv.lorentz_boost(0.1, axis="w")


### PR DESCRIPTION
## Summary
- validate the axis argument for four-vector boosts
- expand test coverage for Lorentz boosts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0cd8d9548324ac64ec2f86a1ebd9