### PR TITLE
Fix CI path generation

### DIFF
--- a/scripts/qa_pipeline.py
+++ b/scripts/qa_pipeline.py
@@ -19,7 +19,7 @@ def scan_repo(root: Path) -> Dict[str, List[str]]:
     """Walk the repository and categorise files by extension."""
     manifest: Dict[str, List[str]] = {key: [] for key in CATEGORIES}
     manifest["ci"].extend(
-        str(p)
+        str(p.relative_to(root))
         for p in (root / ".github" / "workflows").glob("*.yml")
         if p.is_file()
     )


### PR DESCRIPTION
## Summary
- ensure CI file paths in `scan_repo` are relative to repo root

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e1069e5588324b5a60f9f74ba05b3