### PR TITLE
Fix Lorentz boost validation

### DIFF
--- a/e4d/bundle/fourvector.py
+++ b/e4d/bundle/fourvector.py
@@ -39,6 +39,8 @@ class FourVector:
             Spatial axis for the boost – ``"x"``, ``"y"`` or ``"z"``.
         """
 
+        if not -1.0 < beta < 1.0:
+            raise ValueError("beta must satisfy |beta| < 1")
         gamma = 1.0 / np.sqrt(1 - beta ** 2)
         t, x, y, z = self._decode_components()
         if axis == "x":

--- a/tests/test_fourvector.py
+++ b/tests/test_fourvector.py
@@ -31,3 +31,9 @@ def test_invalid_axis():
     fv = FourVector(1.0, 0.0, 0.0, 0.0)
     with pytest.raises(ValueError):
         fv.lorentz_boost(0.1, axis="w")
+
+
+def test_superluminal_beta():
+    fv = FourVector(1.0, 0.0, 0.0, 0.0)
+    with pytest.raises(ValueError):
+        fv.lorentz_boost(1.1)


### PR DESCRIPTION
## Summary
- prevent invalid values in `FourVector.lorentz_boost`
- test for superluminal boost rejection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1069e5588324b5a60f9f74ba05b3