### PR TITLE
Fix duplicate key handling in unify_bibtex

### DIFF
--- a/scripts/qa_pipeline.py
+++ b/scripts/qa_pipeline.py
@@ -78,14 +78,18 @@ def unify_bibtex(root: Path) -> Dict[str, str]:
     seen: set[str] = set()
     with open(refs_dir / "e_series.bib", "w", encoding="utf-8") as out:
         for file in bib_files:
+            skip_entry = False
             for line in file.read_text().splitlines():
                 if line.startswith("@"):
                     key = line.split("{", 1)[1].split(",", 1)[0]
                     if key in seen:
+                        skip_entry = True
                         continue
                     seen.add(key)
                     key_map[key] = str(file.relative_to(root))
-                out.write(line + "\n")
+                    skip_entry = False
+                if not skip_entry:
+                    out.write(line + "\n")
 
     with open(refs_dir / "e_series_keymap.json", "w", encoding="utf-8") as fh:
         json.dump(key_map, fh, indent=2)

--- a/tests/test_qa_pipeline.py
+++ b/tests/test_qa_pipeline.py
@@ -32,3 +32,15 @@ def test_unify_bibtex_creates_key_map(tmp_path: Path) -> None:
     expected = {"refA": "a.bib", "refB": "sub/b.bib"}
     assert key_map == expected
     assert key_map_file == expected
+
+
+def test_unify_bibtex_skips_duplicates(tmp_path: Path) -> None:
+    root = tmp_path
+    (root / "docs" / "refs").mkdir(parents=True)
+    (root / "a.bib").write_text("@book{refA, title={A}}\n")
+    (root / "b.bib").write_text("@article{refA, title={B}}\n  note={dup}\n")
+
+    unify_bibtex(root)
+
+    bib_text = (root / "docs" / "refs" / "e_series.bib").read_text()
+    assert "dup" not in bib_text


### PR DESCRIPTION
## Summary
- handle duplicate keys when combining BibTeX files
- test that duplicate entries are skipped

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1069e5588324b5a60f9f74ba05b3