### PR TITLE
Fix FourVector as_array

### DIFF
--- a/e4d/bundle/fourvector.py
+++ b/e4d/bundle/fourvector.py
@@ -58,5 +58,5 @@ class FourVector:
         return FourVector(t_new, x_new, y_new, z_new)
 
     def as_array(self) -> ndarray:
-        flat = [self.t, self.x.flatten(), self.y.flatten(), self.z.flatten()]
-        return np.hstack(flat)
+        """Return the decoded ``(t, x, y, z)`` components as an array."""
+        return np.array(self._decode_components(), dtype=float)


### PR DESCRIPTION
## Summary
- fix `FourVector.as_array` to return decoded components
- ensure repository passes CI tests after patch

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e1069e5588324b5a60f9f74ba05b3