### PR TITLE
Fix data generator exports

### DIFF
--- a/projects/E8_Model/E1/e1_data_generator.py
+++ b/projects/E8_Model/E1/e1_data_generator.py
@@ -1,31 +1,23 @@
 """
 E1 Data Generator
-
 This module contains the data generator for the E1 group. It is part of the
 E series data generators.
 """
 
 import numpy as np
 
+from projects.E8_Model.base_generator import BaseGenerator
 
-class E1DataGenerator:
+
+class E1DataGenerator(BaseGenerator):
     """A data generator for the E1 group."""
 
-    def __init__(self, data_size=100):
+    def __init__(self, data_size: int = 100):
         """Initialize the data generator with a specified data size."""
-        # Store the desired size of the generated dataset
-        self.data_size = data_size
-        self.data = None
+        super().__init__(data_size)
 
     def generate_data(self):
         """Generate data for the E1 group."""
         # Create a random dataset with a single feature
         self.data = np.random.rand(self.data_size, 1)
-        return self.data
-
-    def get_data(self):
-        """Retrieve the generated data."""
-        # Generate data on demand if it does not already exist
-        if self.data is None:
-            self.generate_data()
         return self.data

--- a/projects/E8_Model/E10/e10_data_generator.py
+++ b/projects/E8_Model/E10/e10_data_generator.py
@@ -1,29 +1,21 @@
 """E10 Data Generator
-
 This module contains the data generator for the E10 group."""
 
 
 import numpy as np
 
+from projects.E8_Model.base_generator import BaseGenerator
 
-class E10DataGenerator:
+
+class E10DataGenerator(BaseGenerator):
     """A data generator for the E10 group."""
 
-    def __init__(self, data_size=100):
+    def __init__(self, data_size: int = 100):
         """Initialize the generator with a specified data size."""
-        # Store the desired size of the generated dataset
-        self.data_size = data_size
-        self.data = None
+        super().__init__(data_size)
 
     def generate_data(self):
         """Generate data for the E10 group."""
         # Create a random dataset with ten features
         self.data = np.random.rand(self.data_size, 10)
-        return self.data
-
-    def get_data(self):
-        """Retrieve the generated data."""
-        # Generate data on demand if it does not already exist
-        if self.data is None:
-            self.generate_data()
         return self.data

--- a/projects/E8_Model/E11/e11_data_generator.py
+++ b/projects/E8_Model/E11/e11_data_generator.py
@@ -1,28 +1,20 @@
 """E11 Data Generator
-
 This module contains the data generator for the E11 group."""
 
 import numpy as np
 
+from projects.E8_Model.base_generator import BaseGenerator
 
-class E11DataGenerator:
+
+class E11DataGenerator(BaseGenerator):
     """A data generator for the E11 group."""
 
-    def __init__(self, data_size=100):
+    def __init__(self, data_size: int = 100):
         """Initialize the generator with a specified data size."""
-        # Store the desired size of the generated dataset
-        self.data_size = data_size
-        self.data = None
+        super().__init__(data_size)
 
     def generate_data(self):
         """Generate data for the E11 group."""
         # Create a random dataset with eleven features
         self.data = np.random.rand(self.data_size, 11)
-        return self.data
-
-    def get_data(self):
-        """Retrieve the generated data."""
-        # Generate data on demand if it does not already exist
-        if self.data is None:
-            self.generate_data()
         return self.data

--- a/projects/E8_Model/E2/e2_data_generator.py
+++ b/projects/E8_Model/E2/e2_data_generator.py
@@ -1,31 +1,23 @@
 """
 E2 Data Generator
-
 This module contains the data generator for the E2 group. It is part of the
 E series data generators.
 """
 
 import numpy as np
 
+from projects.E8_Model.base_generator import BaseGenerator
 
-class E2DataGenerator:
+
+class E2DataGenerator(BaseGenerator):
     """A data generator for the E2 group."""
 
-    def __init__(self, data_size=100):
+    def __init__(self, data_size: int = 100):
         """Initialize the data generator with a specified data size."""
-        # Store the desired size of the generated dataset
-        self.data_size = data_size
-        self.data = None
+        super().__init__(data_size)
 
     def generate_data(self):
         """Generate data for the E2 group."""
         # Create a random dataset with two features
         self.data = np.random.rand(self.data_size, 2)
-        return self.data
-
-    def get_data(self):
-        """Retrieve the generated data."""
-        # Generate data on demand if it does not already exist
-        if self.data is None:
-            self.generate_data()
         return self.data

--- a/projects/E8_Model/E3/e3_data_generator.py
+++ b/projects/E8_Model/E3/e3_data_generator.py
@@ -1,31 +1,23 @@
 """
 E3 Data Generator
-
 This module contains the data generator for the E3 group. It is part of the
 E series data generators.
 """
 
 import numpy as np
 
+from projects.E8_Model.base_generator import BaseGenerator
 
-class E3DataGenerator:
+
+class E3DataGenerator(BaseGenerator):
     """A data generator for the E3 group."""
 
-    def __init__(self, data_size=100):
+    def __init__(self, data_size: int = 100):
         """Initialize the data generator with a specified data size."""
-        # Store the desired size of the generated dataset
-        self.data_size = data_size
-        self.data = None
+        super().__init__(data_size)
 
     def generate_data(self):
         """Generate data for the E3 group."""
         # Create a random dataset with three features
         self.data = np.random.rand(self.data_size, 3)
-        return self.data
-
-    def get_data(self):
-        """Retrieve the generated data."""
-        # Generate data on demand if it does not already exist
-        if self.data is None:
-            self.generate_data()
         return self.data

--- a/projects/E8_Model/E4/e4_data_generator.py
+++ b/projects/E8_Model/E4/e4_data_generator.py
@@ -1,31 +1,23 @@
 """
 E4 Data Generator
-
 This module contains the data generator for the E4 group. It is part of the
 E series data generators.
 """
 
 import numpy as np
 
+from projects.E8_Model.base_generator import BaseGenerator
 
-class E4DataGenerator:
+
+class E4DataGenerator(BaseGenerator):
     """A data generator for the E4 group."""
 
-    def __init__(self, data_size=100):
+    def __init__(self, data_size: int = 100):
         """Initialize the data generator with a specified data size."""
-        # Store the desired size of the generated dataset
-        self.data_size = data_size
-        self.data = None
+        super().__init__(data_size)
 
     def generate_data(self):
         """Generate data for the E4 group."""
         # Create a random dataset with four features
         self.data = np.random.rand(self.data_size, 4)
-        return self.data
-
-    def get_data(self):
-        """Retrieve the generated data."""
-        # Generate data on demand if it does not already exist
-        if self.data is None:
-            self.generate_data()
         return self.data

--- a/projects/E8_Model/E5/e5_data_generator.py
+++ b/projects/E8_Model/E5/e5_data_generator.py
@@ -1,31 +1,23 @@
 """
 E5 Data Generator
-
 This module contains the data generator for the E5 group. It is part of the
 E series data generators.
 """
 
 import numpy as np
 
+from projects.E8_Model.base_generator import BaseGenerator
 
-class E5DataGenerator:
+
+class E5DataGenerator(BaseGenerator):
     """A data generator for the E5 group."""
 
-    def __init__(self, data_size=100):
+    def __init__(self, data_size: int = 100):
         """Initialize the data generator with a specified data size."""
-        # Store the desired size of the generated dataset
-        self.data_size = data_size
-        self.data = None
+        super().__init__(data_size)
 
     def generate_data(self):
         """Generate data for the E5 group."""
         # Create a random dataset with five features
         self.data = np.random.rand(self.data_size, 5)
-        return self.data
-
-    def get_data(self):
-        """Retrieve the generated data."""
-        # Generate data on demand if it does not already exist
-        if self.data is None:
-            self.generate_data()
         return self.data

--- a/projects/E8_Model/E6/e6_data_generator.py
+++ b/projects/E8_Model/E6/e6_data_generator.py
@@ -1,6 +1,5 @@
 """
 E6 Data Generator
-
 This module contains the data generator for the E6 group. It is part of the
 E series data generators.
 """

--- a/projects/E8_Model/E7/e7_data_generator.py
+++ b/projects/E8_Model/E7/e7_data_generator.py
@@ -1,6 +1,5 @@
 """
 E7 Data Generator
-
 This module contains the data generator for the E7 group. It is part of the
 E series data generators.
 """

--- a/projects/E8_Model/E8/e8_data_generator.py
+++ b/projects/E8_Model/E8/e8_data_generator.py
@@ -1,6 +1,5 @@
 """
 E8 Data Generator
-
 This module contains the data generator for the E8 group. It is part of the
 E series data generators.
 """

--- a/projects/E8_Model/E9/e9_data_generator.py
+++ b/projects/E8_Model/E9/e9_data_generator.py
@@ -1,29 +1,21 @@
 """E9 Data Generator
-
 This module contains the data generator for the E9 group. It follows the
 structure used by the lower E groups."""
 
 import numpy as np
 
+from projects.E8_Model.base_generator import BaseGenerator
 
-class E9DataGenerator:
+
+class E9DataGenerator(BaseGenerator):
     """A data generator for the E9 group."""
 
-    def __init__(self, data_size=100):
+    def __init__(self, data_size: int = 100):
         """Initialize the generator with a specified data size."""
-        # Store the desired size of the generated dataset
-        self.data_size = data_size
-        self.data = None
+        super().__init__(data_size)
 
     def generate_data(self):
         """Generate data for the E9 group."""
         # Create a random dataset with nine features
         self.data = np.random.rand(self.data_size, 9)
-        return self.data
-
-    def get_data(self):
-        """Retrieve the generated data."""
-        # Generate data on demand if it does not already exist
-        if self.data is None:
-            self.generate_data()
         return self.data


### PR DESCRIPTION
## Summary
- ensure all E-group data generators subclass `BaseGenerator`
- provide `super().__init__` and restore return statements

## Testing
- `flake8`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e13333234832485e6736eaa2428d8