### PR TITLE
Fix bib consolidation order

### DIFF
--- a/scripts/qa_pipeline.py
+++ b/scripts/qa_pipeline.py
@@ -63,11 +63,11 @@ def unify_bibtex(root: Path) -> Dict[str, str]:
     refs_dir = root / "docs" / "refs"
     refs_dir.mkdir(parents=True, exist_ok=True)
     # ignore previously consolidated output to avoid self-duplication
-    bib_files = [
+    bib_files = sorted(
         p
         for p in root.rglob("*.bib")
         if p.resolve() != (refs_dir / "e_series.bib").resolve()
-    ]
+    )
     key_map: Dict[str, str] = {}
 
     if not bib_files:


### PR DESCRIPTION
## Summary
- preserve deterministic order when consolidating bib files
- all tests pass after sorting `.bib` files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e13333234832485e6736eaa2428d8